### PR TITLE
fix: remove Field wrapping of PatchChannelCommand arguments

### DIFF
--- a/clients/rust/src/models/patch_channel_command.rs
+++ b/clients/rust/src/models/patch_channel_command.rs
@@ -16,19 +16,19 @@ pub struct PatchChannelCommand {
     #[serde(rename = "channelId", skip_serializing_if = "Option::is_none")]
     pub channel_id: Option<uuid::Uuid>,
     #[serde(rename = "environmentVariables", skip_serializing_if = "Option::is_none")]
-    pub environment_variables: Option<Box<crate::models::UpdateEnvironmentVariableDtoListField>>,
+    pub environment_variables: Option<Box<Vec<crate::models::UpdateEnvironmentVariableDto>>>,
     #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
-    pub name: Option<Box<crate::models::StringField>>,
+    pub name: Option<Box<String>>,
     #[serde(rename = "domain", skip_serializing_if = "Option::is_none")]
-    pub domain: Option<Box<crate::models::StringField>>,
+    pub domain: Option<Box<String>>,
     #[serde(rename = "revisionSelectionStrategy", skip_serializing_if = "Option::is_none")]
-    pub revision_selection_strategy: Option<Box<crate::models::ChannelRevisionSelectionStrategyField>>,
+    pub revision_selection_strategy: Option<Box<crate::models::ChannelRevisionSelectionStrategy>>,
     #[serde(rename = "rangeRule", skip_serializing_if = "Option::is_none")]
-    pub range_rule: Option<Box<crate::models::StringField>>,
+    pub range_rule: Option<Box<String>>,
     #[serde(rename = "activeRevisionId", skip_serializing_if = "Option::is_none")]
-    pub active_revision_id: Option<Box<crate::models::GuidNullableField>>,
+    pub active_revision_id: Option<Box<uuid::Uuid>>,
     #[serde(rename = "certificateId", skip_serializing_if = "Option::is_none")]
-    pub certificate_id: Option<Box<crate::models::GuidNullableField>>,
+    pub certificate_id: Option<Box<uuid::Uuid>>,
 }
 
 impl PatchChannelCommand {


### PR DESCRIPTION
Currently, we are wrapping each `PatchChannelCommand` argument in an associated structure. This not only seems unnecessary but also causes empty contents to be sent to Hippo Web, as the command received by Hippo Web contains all null arguments except the `ChannelId` guid which is not field wrapped. This results in a null exception when Hippo Web reads the command.

Removing the wrapping causes requests to patch channels to succeed.

Associated changes are needed in `hippo-cli` client.
Signed-off-by: Kate Goldenring <kate.goldenring@fermyon.com>